### PR TITLE
scripts: add SSH key replacement & removal

### DIFF
--- a/scripts/fleetctl-remove-ssh-user.sh
+++ b/scripts/fleetctl-remove-ssh-user.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -x
+
+name=$1
+if [ -z $name ]; then
+	echo "Provide the name of the keys to remove"
+	exit 1
+fi
+
+shift 1
+
+for machine in $(fleetctl $@ list-machines --no-legend --full | awk '{ print $1;}'); do
+	fleetctl $@ ssh $machine "update-ssh-keys -d $name -n"
+done

--- a/scripts/fleetctl-replace-ssh-keys.sh
+++ b/scripts/fleetctl-replace-ssh-keys.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+
+name=$1
+if [ -z $name ]; then
+	echo "Provide a name for the injected SSH key"
+	exit 1
+fi
+
+shift 1
+
+pubkey=$(cat)
+
+for machine in $(fleetctl $@ list-machines --no-legend --full | awk '{ print $1;}'); do
+	fleetctl $@ ssh $machine "echo '${pubkey}' | update-ssh-keys -a $name"
+done


### PR DESCRIPTION
fleetctl-inject-ssh.sh is a good tool for granting access to the core
user, but it is unable to replace SSH keys or revoke access; this change
adds two scripts to do this.

Usage:

```
`cat ~/.ssh/*pub | ./fleetctl-replace-ssh-key.sh USER`
`./fleetctl-remove-ssh-user USER`
```

The above are orthogonal to:

```
`cat ~/.ssh/*pub | ./fleetctl-inject-ssh.sh USER`
```
